### PR TITLE
Modify bug in MCode_ParseClean function

### DIFF
--- a/MCode4GCC.ahk
+++ b/MCode4GCC.ahk
@@ -287,7 +287,7 @@ MCode_ParseClean(data) {
 	ndata:=""
 	Loop, Parse, data, `n, `r
 	{
-		if Instr(A_LoopField,".ident	" """" "GCC: (GNU)")
+		if Instr(A_LoopField,".ident	" """" "GCC:")
 			return ndata
 		ndata .= A_LoopField "`n"
 	}


### PR DESCRIPTION
Here's the result of my GCC
```
109 013a 90909090 		.ident	"GCC: (tdm64-1) 5.1.0"
```

This is why the MCode_ParseClean function did not function properly.  
if Instr(A_LoopField,__".ident	" """" "GCC: (GNU)"__)  
(line number 290)